### PR TITLE
build: add Google Services and Firebase dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
+apply plugin: 'com.google.gms.google-services'
+
 
 def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
 
@@ -149,6 +151,8 @@ android {
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
+    implementation platform('com.google.firebase:firebase-bom:33.12.0')
+    implementation 'com.google.firebase:firebase-analytics'
 
     def isGifEnabled = (findProperty('expo.gif.enabled') ?: "") == "true";
     def isWebpEnabled = (findProperty('expo.webp.enabled') ?: "") == "true";
@@ -173,4 +177,8 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    debugImplementation 'host.exp.exponent:expo-dev-launcher:5.0.35'
+    releaseImplementation files() // Prevents it from breaking release build
+
 }

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "471625841737",
+    "project_id": "uber-eats-clone-16f71",
+    "storage_bucket": "uber-eats-clone-16f71.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:471625841737:android:604613a3e5062dd8a65398",
+        "android_client_info": {
+          "package_name": "com.chiragdhunna.UBER_EATS_CLONE_PROJECT"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAuQN-pnptR-SDSItfxIozAFOt42TYnPfM"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,7 @@ buildscript {
         classpath('com.android.tools.build:gradle')
         classpath('com.facebook.react:react-native-gradle-plugin')
         classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')
+        classpath 'com.google.gms:google-services:4.4.2'
     }
 }
 


### PR DESCRIPTION
Add Google Services plugin and Firebase dependencies to the Android build configuration to enable Firebase integration in the project. This includes adding the necessary classpath, applying the plugin, and including Firebase BOM and analytics dependencies.